### PR TITLE
v0.2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,138 @@
+# Contributing to niri-autostart
+
+Thanks for taking the time to contribute. This document describes the
+branching model, commit style, and release flow used in this repository.
+
+> History before `v0.1.12` used a different, ad-hoc flow (direct commits to
+> `main`, inline version bumps). Everything from `v0.1.12` onward follows the
+> rules below — please ignore the older history as a style reference.
+
+## Branches
+
+- **`main`** — release branch. Contains only released versions; one commit
+  per tagged release (`v*.*.*`). Contributors do not interact with `main` —
+  releases are cut by maintainers (see [Releases](#release-process-maintainers)).
+- **`dev`** — integration branch. All real development happens here. All
+  contributor PRs target `dev`.
+
+## Contributor workflow
+
+1. Branch off `dev`:
+
+   ```sh
+   git switch dev
+   git pull
+   git switch -c feat/short-description
+   ```
+
+2. Make your changes. Keep commits small and well-named (see
+   [Commit messages](#commit-messages)). Multiple commits per PR are fine
+   and encouraged — they are preserved on `dev`.
+
+3. Open a pull request against `dev`.
+
+## Commit messages
+
+Your commits are preserved verbatim on `dev` (maintainers merge with rebase,
+not squash), so author and message stay yours. Use
+[Conventional Commits](https://www.conventionalcommits.org/):
+
+| Prefix      | Use for                                                    |
+| ----------- | ---------------------------------------------------------- |
+| `feat:`     | user-visible new functionality                             |
+| `fix:`      | bug fix                                                    |
+| `chore:`    | tooling, deps, version bumps, no behavior change           |
+| `refactor:` | internal restructuring, no behavior change                 |
+| `docs:`     | documentation only                                         |
+| `ci:`       | GitHub Actions / pipelines                                 |
+| `test:`     | tests only                                                 |
+| `perf:`     | performance change with no functional difference           |
+
+Rules:
+
+- Subject in imperative mood, lowercase after the prefix, no trailing
+  period.
+- Keep the subject under ~72 characters.
+- If a scope helps, use `feat(ipc): ...` style.
+- Put the "why" in the body when it is not obvious from the diff.
+
+Examples (real commits from the repo):
+
+```
+fix: Pin niri-ipc version
+fix: Update for compatibility with Niri 26.04
+feat: Add installation section to README
+chore: bump to v0.1.12
+```
+
+## Local development
+
+```sh
+cargo build
+cargo test
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all
+```
+
+Please make sure `cargo fmt` and `cargo clippy` are clean before opening a
+PR.
+
+## Pull request checklist
+
+- [ ] Branched off latest `dev`.
+- [ ] Commits follow the [commit message](#commit-messages) style.
+- [ ] `cargo fmt`, `cargo clippy`, `cargo test` pass locally.
+
+---
+
+## Maintainers
+
+This section is for repository maintainers. Contributors do not need to
+follow it.
+
+### Merging into `dev`
+
+Merge contributor PRs into `dev` with **Rebase and merge**. Rebase keeps the
+original commits and their authorship, which is why we ask contributors to
+write Conventional Commit messages — they end up on `dev` unchanged.
+
+If a PR has noisy commits ("wip", "fix typo", "address review") ask the
+author to clean them up (or do it yourself) before rebasing.
+
+### Release process
+
+Releases are always cut from `dev` into `main` and are **always** merged
+with **Squash and merge** — no exceptions.
+
+1. On `dev` (via a normal PR), bump the version in `Cargo.toml` and refresh
+   `Cargo.lock`:
+
+   ```
+   chore: bump to vX.Y.Z
+   ```
+
+2. Open a PR `dev` → `main`.
+
+3. Merge it with **Squash and merge**. The squash commit title must be
+   exactly the version, e.g. `v0.1.12` — no prefix, no extra words. This is
+   the only commit style on `main`.
+
+4. Tag the resulting squash commit on `main` with the same name and push
+   the tag:
+
+   ```sh
+   git switch main
+   git pull
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+5. Pushing the tag triggers `.github/workflows/release.yml`, which builds
+   the binaries and creates the GitHub release. On success,
+   `.github/workflows/aur.yml` updates the AUR packages.
+
+Notes:
+
+- Versioning follows [SemVer](https://semver.org/): bump MAJOR for breaking
+  changes, MINOR for new features, PATCH for bug fixes.
+- The tag name and the squash commit title must match exactly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,19 +17,59 @@ branching model, commit style, and release flow used in this repository.
 
 ## Contributor workflow
 
-1. Branch off `dev`:
+The flow below uses [`gh`](https://cli.github.com/) end-to-end. If you do not
+have `gh` installed, the equivalent web-UI steps work too — the rules
+(branch off `dev`, target `dev`, follow the commit style) are what matter.
+
+1. Fork the repository and clone your fork. `gh repo fork --clone` does both
+   in one step and sets `upstream` to point at the canonical repository:
+
+   ```sh
+   gh repo fork partanskiy/niri-autostart --clone
+   cd niri-autostart
+   ```
+
+   If you already have a clone of the upstream, run `gh repo fork --remote`
+   from inside it instead — it adds your fork as a remote without recloning.
+
+2. Branch off `dev` (sync from upstream first):
 
    ```sh
    git switch dev
-   git pull
+   git pull upstream dev
    git switch -c feat/short-description
    ```
 
-2. Make your changes. Keep commits small and well-named (see
+3. Make your changes. Keep commits small and well-named (see
    [Commit messages](#commit-messages)). Multiple commits per PR are fine
    and encouraged — they are preserved on `dev`.
 
-3. Open a pull request against `dev`.
+4. Push the branch to your fork and open a pull request against
+   `partanskiy/niri-autostart:dev`:
+
+   ```sh
+   git push -u origin feat/short-description
+   gh pr create \
+     --repo partanskiy/niri-autostart \
+     --base dev \
+     --title "feat: short description" \
+     --body  "Why this change is needed and what it does."
+   ```
+
+   `gh pr create --web` opens the prefilled PR form in the browser if you
+   prefer to write the description there.
+
+5. While review is in progress:
+
+   ```sh
+   gh pr status                       # see your PR's review/CI state
+   gh pr checks                       # tail CI results
+   gh pr view --web                   # open the PR in the browser
+   ```
+
+   Push follow-up commits to the same branch — the PR updates automatically.
+   Do not force-push to rewrite history that reviewers have already seen
+   unless asked; a maintainer will tidy commits at merge time if needed.
 
 ## Commit messages
 
@@ -99,23 +139,52 @@ write Conventional Commit messages — they end up on `dev` unchanged.
 If a PR has noisy commits ("wip", "fix typo", "address review") ask the
 author to clean them up (or do it yourself) before rebasing.
 
+Full `gh` flow:
+
+```sh
+gh pr view <num>                        # sanity-check title, base, commits
+gh pr checks <num>                      # confirm CI is green
+gh pr review <num> --approve            # optional: leave an approval
+gh pr merge  <num> --rebase --delete-branch
+```
+
+`--rebase` is the squash/merge/rebase selector — it must be `--rebase` for
+PRs into `dev`. `--delete-branch` removes the contributor's topic branch on
+the fork side after the merge.
+
 ### Release process
 
 Releases are always cut from `dev` into `main` and are **always** merged
 with **Squash and merge** — no exceptions.
 
 1. On `dev` (via a normal PR), bump the version in `Cargo.toml` and refresh
-   `Cargo.lock`:
+   `Cargo.lock` with a commit named `chore: bump to vX.Y.Z`.
 
+2. Open a release PR `dev` → `main`:
+
+   ```sh
+   gh pr create \
+     --base main \
+     --head dev \
+     --title "vX.Y.Z" \
+     --body  "Release vX.Y.Z."
    ```
-   chore: bump to vX.Y.Z
+
+   The PR title is set to the bare version on purpose — see step 3.
+
+3. Merge the release PR with **Squash and merge**. The squash commit title
+   must be exactly the version, e.g. `v0.1.12` — no prefix, no extra words.
+   This is the only commit style on `main`. Use `gh` to enforce both the
+   strategy and the subject:
+
+   ```sh
+   gh pr merge <num> \
+     --squash \
+     --subject "vX.Y.Z" \
+     --body    ""
    ```
 
-2. Open a PR `dev` → `main`.
-
-3. Merge it with **Squash and merge**. The squash commit title must be
-   exactly the version, e.g. `v0.1.12` — no prefix, no extra words. This is
-   the only commit style on `main`.
+   Do **not** pass `--delete-branch` — `dev` must survive the merge.
 
 4. Tag the resulting squash commit on `main` with the same name and push
    the tag:
@@ -129,7 +198,12 @@ with **Squash and merge** — no exceptions.
 
 5. Pushing the tag triggers `.github/workflows/release.yml`, which builds
    the binaries and creates the GitHub release. On success,
-   `.github/workflows/aur.yml` updates the AUR packages.
+   `.github/workflows/aur.yml` updates the AUR packages. Watch the run with:
+
+   ```sh
+   gh run watch
+   gh release view vX.Y.Z
+   ```
 
 Notes:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -37,15 +37,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -127,15 +127,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "hashbrown"
@@ -170,9 +170,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "knuffel"
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "niri-ipc"
-version = "25.11.0"
+version = "26.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bd9eb4e437f5282ce853cf66837658379cb537b4b6bae687da59246005329a"
+checksum = "6a4adbddf4037ce047854d36a60b5bf80a7990b8db2f0a0b9ede7534b0bae09a"
 dependencies = [
  "serde",
  "serde_json",
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -423,9 +423,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -462,18 +462,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "niri-autostart"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "clap",
  "knuffel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,8 @@ dependencies = [
  "clap",
  "knuffel",
  "niri-ipc",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "niri-autostart"
-version = "0.1.12"
+version = "0.2.0"
 dependencies = [
  "clap",
  "knuffel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "niri-autostart"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 rust-version = "1.94"
 description = "Declarative autostart and layout restoration for the niri Wayland compositor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ license = "GPL-3.0-or-later"
 [dependencies]
 clap = { version = "4.5.60", features = ["derive"] }
 knuffel = "3.2.0"
-niri-ipc = "26.4.0"
+niri-ipc = "=26.4.0"
 thiserror = "2.0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ license = "GPL-3.0-or-later"
 [dependencies]
 clap = { version = "4.5.60", features = ["derive"] }
 knuffel = "3.2.0"
-niri-ipc = "=25.11.0"
+niri-ipc = "26.4.0"
 thiserror = "2.0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,6 @@ license = "GPL-3.0-or-later"
 clap = { version = "4.5.60", features = ["derive"] }
 knuffel = "3.2.0"
 niri-ipc = "=26.4.0"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 thiserror = "2.0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "niri-autostart"
-version = "0.1.12"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.94"
 description = "Declarative autostart and layout restoration for the niri Wayland compositor"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <p align="center">Declarative autostart and layout restoration for niri.</p>
 
 <p align="center">
-    <a href="#about">About</a> | <a href="#configuration">Configuration</a> | <a href="#status">Status</a>
+    <a href="#about">About</a> | <a href="#configuration">Configuration</a> | <a href="#installation">Installation</a> | <a href="#status">Status</a>
 </p>
 
 ## About
@@ -24,6 +24,24 @@ It is intended to replace ad-hoc startup shell scripts with a small event-driven
 - Reuses existing windows by exact `app-id`
 - Prefers the matching tiled window on the target workspace when duplicates exist
 - Can be launched directly from `startup.kdl`
+
+## Installation
+
+### AUR
+
+```sh
+paru -S niri-autostart
+```
+
+Or prebuilt binary
+
+```sh
+paru -S niri-autostart-bin
+```
+
+### Binary releases
+
+You can download a binary release [here](https://github.com/partanskiy/niri-autostart/releases)
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ It is intended to replace ad-hoc startup shell scripts with a small event-driven
 - Declarative KDL config with `workspace`, `column` and `window`
 - Uses `niri-ipc` types directly
 - Waits on real `event-stream` state changes
-- Reuses existing windows by exact `app-id`
-- Prefers the matching tiled window on the target workspace when duplicates exist
+- Tracks windows it spawned in a runtime state file under `/tmp`
+- Reuses recorded live `window_id`s; falls back to exact `app-id` for app ids that are unique in the config
 - Can be launched directly from `startup.kdl`
 
 ## Installation
@@ -55,8 +55,21 @@ autostart {
                 proportion 1.0
             }
 
-            window app-id="cursor" {
-                command "cursor"
+            window app-id="kitty" {
+                command "terminal" "-e" "nvim"
+                height {
+                    proportion 1.0
+                }
+            }
+        }
+
+        column {
+            width {
+                proportion 1.0
+            }
+
+            window app-id="kitty" {
+                command "terminal" "-e" "fish" "-lc" "cl"
                 height {
                     proportion 1.0
                 }
@@ -113,29 +126,29 @@ autostart {
                 proportion 0.33333
             }
 
-            window app-id="fw-fastfetch" {
-                command "terminal" "--class" "fw-fastfetch" "-e" "fastfetch" "--dynamic-interval" "500" "--hide-cursor" "true"
+            window app-id="kitty" {
+                command "terminal" "-e" "fastfetch" "--dynamic-interval" "500" "--hide-cursor" "true"
                 height {
                     fixed 284
                 }
             }
 
-            window app-id="fw-tty-clock" {
-                command "terminal" "--class" "fw-tty-clock" "-e" "tty-clock" "-sc"
+            window app-id="kitty" {
+                command "terminal" "-e" "tty-clock" "-sc"
                 height {
                     fixed 207
                 }
             }
 
-            window app-id="fw-cava" {
-                command "terminal" "--class" "fw-cava" "-e" "cava" "-p" "~/.config/cava/themes/noctalia"
+            window app-id="kitty" {
+                command "terminal" "-e" "cava" "-p" "~/.config/cava/themes/noctalia"
                 height {
                     fixed 392
                 }
             }
 
-            window app-id="fw-cmatrix" {
-                command "terminal" "--class" "fw-cmatrix" "-e" "cmatrix"
+            window app-id="kitty" {
+                command "terminal" "-e" "cmatrix"
                 height {
                     fixed 172
                 }
@@ -146,15 +159,15 @@ autostart {
                 proportion 0.66667
             }
 
-            window app-id="fw-btop" {
-                command "terminal" "--class" "fw-btop" "-e" "btop"
+            window app-id="kitty" {
+                command "terminal" "-e" "btop"
                 height {
                     fixed 661
                 }
             }
 
-            window app-id="fw-asciiquarium" {
-                command "terminal" "--class" "fw-asciiquarium" "-e" "asciiquarium"
+            window app-id="kitty" {
+                command "terminal" "-e" "asciiquarium"
                 height {
                     fixed 404
                 }
@@ -168,8 +181,8 @@ autostart {
                 fixed 720
             }
 
-            window app-id="scratchpad" floating=true {
-                command "kitty" "--class" "scratchpad" "-1"
+            window app-id="kitty" floating=true {
+                command "terminal"
                 height {
                     proportion 1.0
                 }
@@ -183,10 +196,24 @@ This example shows the full schema:
 
 - multiple `workspace` blocks (monitor assignment is configured in niri itself)
 - `column` width as `fixed` or `proportion`
-- `window` matching by exact `app-id`
+- `window app-id` as the expected app id after spawn and as a unique-app fallback
+- repeated `app-id` values are allowed
 - `command` as an argv-style list
 - `height` as `fixed` or `proportion`
 - optional `floating=true`
+
+For repeated `app-id` values, `niri-autostart` does not require title or class
+markers. It records the concrete niri `window_id` that appeared after each `spawn`
+in:
+
+```text
+/tmp/niri-autostart/windows.json
+```
+
+On later runs in the same niri session, live recorded window ids are reused. If the
+state file is missing, windows with repeated app ids are spawned again because
+there is no reliable way to distinguish unrelated existing windows with the same
+app id.
 
 The default config path is:
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -11,7 +11,7 @@
 
 ## IPC Types
 
-The implementation uses `niri-ipc = "=25.11.0"` directly and treats its IPC types as canonical:
+The implementation uses `niri-ipc = "=26.4.0"` directly and treats its IPC types as canonical:
 
 - `Request`
 - `Response`
@@ -39,8 +39,8 @@ autostart {
                 width {
                     proportion 0.33333
                 }
-                window app-id="fw-fastfetch" floating=true {
-                    command "terminal" "--class" "fw-fastfetch" "-e" "fastfetch"
+                window app-id="kitty" floating=true {
+                    command "terminal" "-e" "fastfetch"
                     height {
                         fixed 284
                     }
@@ -53,17 +53,22 @@ autostart {
 
 Rules in v1:
 
-- exact `app-id` matching only
-- `app-id` must be unique across the whole config
+- exact `app-id` fallback only for app ids that are unique in the config
+- repeated app ids are allowed
+- repeated app ids are identified by runtime state after `spawn`, not by title/class markers
 - no regex matching
-- no title matching
-- no PID matching
+- no PID matching as the primary identity
 - no include files
 
 Default config path:
 
 - `~/.config/niri-autostart/config.kdl`
 - overridable via `--config`
+
+Runtime state path:
+
+- `/tmp/niri-autostart/windows.json`
+- overridable via `--state`
 
 ## State and Reduction
 
@@ -77,6 +82,16 @@ The runtime state keeps:
   - app-id to window ids
   - `(workspace_id, column, row)` to window id
 - last `ConfigLoaded` status
+
+The persisted runtime state keeps, per config position:
+
+- workspace name
+- column index
+- row index
+- niri `window_id`
+- observed `app_id`
+- observed PID, when niri provides one
+- command argv from the config
 
 Reducer behavior:
 
@@ -105,7 +120,10 @@ Reconcile order:
 
 Window handling:
 
-- if the managed window is missing, spawn it
+- if a live recorded `window_id` exists for the config position, use it
+- otherwise, if the app id is unique in the config, fall back to exact `app-id`
+- otherwise, spawn and wait for a new window with the expected `app_id`
+- after spawn, record the resulting `window_id` in runtime state
 - if it exists on another workspace, move it
 - first window of a column is treated as the anchor of that column
 - later windows are merged into the column via `ConsumeWindowIntoColumn`

--- a/examples/autostart.kdl
+++ b/examples/autostart.kdl
@@ -1,57 +1,57 @@
 autostart {
     workspace "firework" {
         column {
-                width {
-                    proportion 0.33333
-                }
+            width {
+                proportion 0.33333
+            }
 
-                window app-id="fw-fastfetch" {
-                    command "terminal" "--class" "fw-fastfetch" "-e" "fastfetch" "--dynamic-interval" "500" "--hide-cursor" "true"
-                    height {
-                        fixed 284
-                    }
-                }
-
-                window app-id="fw-tty-clock" {
-                    command "terminal" "--class" "fw-tty-clock" "-e" "tty-clock" "-sc"
-                    height {
-                        fixed 207
-                    }
-                }
-
-                window app-id="fw-cava" {
-                    command "terminal" "--class" "fw-cava" "-e" "cava" "-p" "~/.config/cava/themes/noctalia"
-                    height {
-                        fixed 392
-                    }
-                }
-
-                window app-id="fw-cmatrix" {
-                    command "terminal" "--class" "fw-cmatrix" "-e" "cmatrix"
-                    height {
-                        fixed 172
-                    }
+            window app-id="kitty" {
+                command "terminal" "-e" "fastfetch" "--dynamic-interval" "500" "--hide-cursor" "true"
+                height {
+                    fixed 284
                 }
             }
 
-            column {
-                width {
-                    proportion 0.66667
-                }
-
-                window app-id="fw-btop" {
-                    command "terminal" "--class" "fw-btop" "-e" "btop"
-                    height {
-                        fixed 661
-                    }
-                }
-
-                window app-id="fw-asciiquarium" {
-                    command "terminal" "--class" "fw-asciiquarium" "-e" "asciiquarium"
-                    height {
-                        fixed 404
-                    }
+            window app-id="kitty" {
+                command "terminal" "-e" "tty-clock" "-sc"
+                height {
+                    fixed 207
                 }
             }
+
+            window app-id="kitty" {
+                command "terminal" "-e" "cava" "-p" "~/.config/cava/themes/noctalia"
+                height {
+                    fixed 392
+                }
+            }
+
+            window app-id="kitty" {
+                command "terminal" "-e" "cmatrix"
+                height {
+                    fixed 172
+                }
+            }
+        }
+
+        column {
+            width {
+                proportion 0.66667
+            }
+
+            window app-id="kitty" {
+                command "terminal" "-e" "btop"
+                height {
+                    fixed 661
+                }
+            }
+
+            window app-id="kitty" {
+                command "terminal" "-e" "asciiquarium"
+                height {
+                    fixed 404
+                }
+            }
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::env;
 use std::ffi::OsStr;
 use std::fs;
@@ -15,6 +14,8 @@ type AppResult<T> = crate::error::Result<T>;
 pub struct Cli {
     #[arg(long)]
     pub config: Option<PathBuf>,
+    #[arg(long)]
+    pub state: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -132,7 +133,9 @@ impl Config {
 
     pub fn default_path() -> AppResult<PathBuf> {
         if let Some(path) = env::var_os("XDG_CONFIG_HOME") {
-            return Ok(PathBuf::from(path).join("niri-autostart").join("config.kdl"));
+            return Ok(PathBuf::from(path)
+                .join("niri-autostart")
+                .join("config.kdl"));
         }
 
         if let Some(home) = env::var_os("HOME") {
@@ -158,8 +161,6 @@ impl Config {
     }
 
     fn validate(&self) -> AppResult<()> {
-        let mut app_ids = HashSet::new();
-
         if self.workspaces.is_empty() {
             return Err(NiriAutostartError::Validation(
                 "at least one `workspace` node is required".to_string(),
@@ -183,13 +184,6 @@ impl Config {
                 }
 
                 for window in &column.windows {
-                    if !app_ids.insert(window.app_id.clone()) {
-                        return Err(NiriAutostartError::Validation(format!(
-                            "duplicate app-id {:?} in config",
-                            window.app_id
-                        )));
-                    }
-
                     if window.command.is_empty() {
                         return Err(NiriAutostartError::Validation(format!(
                             "window {:?} must have a non-empty command",
@@ -282,8 +276,8 @@ mod tests {
                         width {
                             fixed 640
                         }
-                        window app-id="fw-fastfetch" {
-                            command "terminal" "--class" "fw-fastfetch" "-e" "fastfetch"
+                        window app-id="kitty" {
+                            command "terminal" "-e" "fastfetch"
                             height {
                                 fixed 284
                             }
@@ -296,35 +290,59 @@ mod tests {
         .unwrap();
 
         assert_eq!(config.workspaces.len(), 1);
-        assert_eq!(
-            config.workspaces[0].columns[0].windows[0].app_id,
-            "fw-fastfetch"
-        );
+        assert_eq!(config.workspaces[0].columns[0].windows[0].app_id, "kitty");
     }
 
     #[test]
-    fn rejects_duplicate_app_ids() {
-        let err = parse(
+    fn allows_duplicate_app_ids() {
+        let config = parse(
             r#"
             autostart {
-                workspace "firework" {
+                workspace "code" {
                     column {
                         width {
-                            fixed 640
+                            proportion 1.0
                         }
-                        window app-id="dup" {
-                            command "a"
+                        window app-id="kitty" {
+                            command "terminal" "-e" "nvim"
                             height {
-                                fixed 1
+                                proportion 1.0
                             }
                         }
                     }
                     column {
                         width {
+                            proportion 1.0
+                        }
+                        window app-id="kitty" {
+                            command "terminal" "-e" "fish" "-lc" "cl"
+                            height {
+                                proportion 1.0
+                            }
+                        }
+                    }
+                }
+            }
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.workspaces[0].columns[0].windows[0].app_id, "kitty");
+        assert_eq!(config.workspaces[0].columns[1].windows[0].app_id, "kitty");
+    }
+
+    #[test]
+    fn rejects_title_property() {
+        let err = parse(
+            r#"
+            autostart {
+                workspace "code" {
+                    column {
+                        width {
                             fixed 640
                         }
-                        window app-id="dup" {
-                            command "b"
+                        window app-id="kitty" title="forbidden-title" {
+                            command "terminal"
                             height {
                                 fixed 1
                             }
@@ -336,7 +354,7 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(err.to_string().contains("duplicate app-id"));
+        assert!(err.to_string().contains("unexpected"));
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,18 @@ pub enum NiriAutostartError {
     #[error("failed to parse config from {path}: {message}")]
     ConfigParse { path: PathBuf, message: String },
 
+    #[error("failed to read runtime state from {path}: {source}")]
+    RuntimeStateRead { path: PathBuf, source: io::Error },
+
+    #[error("failed to write runtime state to {path}: {source}")]
+    RuntimeStateWrite { path: PathBuf, source: io::Error },
+
+    #[error("failed to parse runtime state from {path}: {message}")]
+    RuntimeStateParse { path: PathBuf, message: String },
+
+    #[error("failed to serialize runtime state: {0}")]
+    RuntimeStateSerialize(String),
+
     #[error("config validation failed: {0}")]
     Validation(String),
 
@@ -41,7 +53,9 @@ pub enum NiriAutostartError {
     #[error("window with app-id {0:?} was not found in niri state")]
     MissingWindow(String),
 
-    #[error("managed window {app_id:?} is in column {actual}, cannot consume it into column {expected_left} because it is not immediately to the right")]
+    #[error(
+        "managed window {app_id:?} is in column {actual}, cannot consume it into column {expected_left} because it is not immediately to the right"
+    )]
     NonAdjacentColumn {
         app_id: String,
         actual: usize,

--- a/src/event_adapter.rs
+++ b/src/event_adapter.rs
@@ -1,0 +1,231 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use niri_ipc::Event;
+
+use crate::error::{NiriAutostartError, Result};
+use crate::ipc::{EventMessage, EventStream};
+use crate::reducer::apply_event;
+use crate::state::ActualState;
+
+const HISTORY_LIMIT: usize = 512;
+
+#[derive(Debug, Default)]
+struct EventAdapterState {
+    state: ActualState,
+    seq: u64,
+    saw_workspaces: bool,
+    saw_windows: bool,
+    closed: Option<String>,
+    history: VecDeque<(u64, Event)>,
+}
+
+pub struct EventAdapter {
+    inner: Arc<(Mutex<EventAdapterState>, Condvar)>,
+    _applier: thread::JoinHandle<()>,
+}
+
+impl EventAdapter {
+    pub fn connect(initial_timeout: Duration) -> Result<Self> {
+        let stream = EventStream::connect()?;
+        let rx = stream.into_receiver();
+        let inner = Arc::new((Mutex::new(EventAdapterState::default()), Condvar::new()));
+        let applier_inner = Arc::clone(&inner);
+
+        let applier = thread::spawn(move || {
+            while let Ok(message) = rx.recv() {
+                let (lock, cvar) = &*applier_inner;
+                let mut guard = lock.lock().expect("event adapter lock poisoned");
+
+                match message {
+                    EventMessage::Event(event) => {
+                        guard.seq += 1;
+                        let seq = guard.seq;
+
+                        if matches!(event, Event::WorkspacesChanged { .. }) {
+                            guard.saw_workspaces = true;
+                        }
+                        if matches!(event, Event::WindowsChanged { .. }) {
+                            guard.saw_windows = true;
+                        }
+
+                        apply_event(&mut guard.state, event.clone());
+                        guard.history.push_back((seq, event));
+                        while guard.history.len() > HISTORY_LIMIT {
+                            guard.history.pop_front();
+                        }
+                    }
+                    EventMessage::Closed(message) => {
+                        guard.closed = Some(message);
+                    }
+                }
+
+                cvar.notify_all();
+            }
+        });
+
+        let adapter = Self {
+            inner,
+            _applier: applier,
+        };
+        adapter.wait_for_initial_state(initial_timeout)?;
+        Ok(adapter)
+    }
+
+    pub fn state(&self) -> ActualState {
+        self.inner
+            .0
+            .lock()
+            .expect("event adapter lock poisoned")
+            .state
+            .clone()
+    }
+
+    pub fn wait_for<F>(&self, timeout: Duration, what: String, predicate: F) -> Result<()>
+    where
+        F: Fn(&ActualState) -> bool,
+    {
+        self.wait_loop(timeout, what, |guard| predicate(&guard.state))
+    }
+
+    pub fn wait_for_stable<F>(
+        &self,
+        timeout: Duration,
+        quiet_for: Duration,
+        what: String,
+        predicate: F,
+    ) -> Result<()>
+    where
+        F: Fn(&ActualState) -> bool,
+    {
+        let start = Instant::now();
+        let (lock, cvar) = &*self.inner;
+        let mut guard = lock.lock().expect("event adapter lock poisoned");
+
+        loop {
+            if let Some(message) = &guard.closed {
+                return Err(NiriAutostartError::EventStreamClosed(message.clone()));
+            }
+
+            let remaining = timeout.checked_sub(start.elapsed()).ok_or_else(|| {
+                NiriAutostartError::Timeout {
+                    what: what.clone(),
+                    timeout,
+                }
+            })?;
+
+            if predicate(&guard.state) {
+                let wait_for = quiet_for.min(remaining);
+                let stable_seq = guard.seq;
+                let (next_guard, wait_result) = cvar
+                    .wait_timeout(guard, wait_for)
+                    .expect("event adapter lock poisoned");
+                guard = next_guard;
+
+                if wait_result.timed_out() && guard.seq == stable_seq && predicate(&guard.state) {
+                    if wait_for == quiet_for {
+                        return Ok(());
+                    }
+
+                    return Err(NiriAutostartError::Timeout {
+                        what: what.clone(),
+                        timeout,
+                    });
+                }
+
+                continue;
+            }
+
+            let (next_guard, wait_result) = cvar
+                .wait_timeout(guard, remaining)
+                .expect("event adapter lock poisoned");
+            guard = next_guard;
+
+            if wait_result.timed_out() && !predicate(&guard.state) {
+                return Err(NiriAutostartError::Timeout { what, timeout });
+            }
+        }
+    }
+
+    pub fn wait_until_quiet(
+        &self,
+        timeout: Duration,
+        quiet_for: Duration,
+        what: String,
+    ) -> Result<()> {
+        let start = Instant::now();
+        let (lock, cvar) = &*self.inner;
+        let mut guard = lock.lock().expect("event adapter lock poisoned");
+
+        loop {
+            if let Some(message) = &guard.closed {
+                return Err(NiriAutostartError::EventStreamClosed(message.clone()));
+            }
+
+            let remaining = timeout.checked_sub(start.elapsed()).ok_or_else(|| {
+                NiriAutostartError::Timeout {
+                    what: what.clone(),
+                    timeout,
+                }
+            })?;
+            let wait_for = quiet_for.min(remaining);
+            let stable_seq = guard.seq;
+            let (next_guard, wait_result) = cvar
+                .wait_timeout(guard, wait_for)
+                .expect("event adapter lock poisoned");
+            guard = next_guard;
+
+            if wait_result.timed_out() && guard.seq == stable_seq {
+                if wait_for == quiet_for {
+                    return Ok(());
+                }
+
+                return Err(NiriAutostartError::Timeout { what, timeout });
+            }
+        }
+    }
+
+    fn wait_for_initial_state(&self, timeout: Duration) -> Result<()> {
+        self.wait_loop(
+            timeout,
+            "initial niri event-stream state".to_string(),
+            |guard| guard.saw_workspaces && guard.saw_windows,
+        )
+    }
+
+    fn wait_loop<F>(&self, timeout: Duration, what: String, predicate: F) -> Result<()>
+    where
+        F: Fn(&EventAdapterState) -> bool,
+    {
+        let start = Instant::now();
+        let (lock, cvar) = &*self.inner;
+        let mut guard = lock.lock().expect("event adapter lock poisoned");
+
+        loop {
+            if predicate(&guard) {
+                return Ok(());
+            }
+
+            if let Some(message) = &guard.closed {
+                return Err(NiriAutostartError::EventStreamClosed(message.clone()));
+            }
+
+            let remaining = timeout.checked_sub(start.elapsed()).ok_or_else(|| {
+                NiriAutostartError::Timeout {
+                    what: what.clone(),
+                    timeout,
+                }
+            })?;
+            let (next_guard, wait_result) = cvar
+                .wait_timeout(guard, remaining)
+                .expect("event adapter lock poisoned");
+            guard = next_guard;
+
+            if wait_result.timed_out() && !predicate(&guard) {
+                return Err(NiriAutostartError::Timeout { what, timeout });
+            }
+        }
+    }
+}

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -36,7 +36,6 @@ impl CommandClient {
             Err(message) => Err(NiriAutostartError::Niri(message)),
         }
     }
-
 }
 
 impl EventStream {
@@ -45,22 +44,28 @@ impl EventStream {
         let reply: Reply = socket.send(Request::EventStream)?;
         match reply {
             Ok(Response::Handled) => {}
-            Ok(_) => return Err(NiriAutostartError::UnexpectedReply { context: "event-stream" }),
+            Ok(_) => {
+                return Err(NiriAutostartError::UnexpectedReply {
+                    context: "event-stream",
+                });
+            }
             Err(message) => return Err(NiriAutostartError::Niri(message)),
         }
 
         let (tx, rx) = mpsc::channel();
         let mut read_event = socket.read_events();
-        let reader = thread::spawn(move || loop {
-            match read_event() {
-                Ok(event) => {
-                    if tx.send(EventMessage::Event(event)).is_err() {
+        let reader = thread::spawn(move || {
+            loop {
+                match read_event() {
+                    Ok(event) => {
+                        if tx.send(EventMessage::Event(event)).is_err() {
+                            break;
+                        }
+                    }
+                    Err(err) => {
+                        let _ = tx.send(EventMessage::Closed(err.to_string()));
                         break;
                     }
-                }
-                Err(err) => {
-                    let _ = tx.send(EventMessage::Closed(err.to_string()));
-                    break;
                 }
             }
         });
@@ -69,5 +74,10 @@ impl EventStream {
             rx,
             _reader: reader,
         })
+    }
+
+    pub fn into_receiver(self) -> Receiver<EventMessage> {
+        let Self { rx, _reader } = self;
+        rx
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,28 +1,33 @@
 mod config;
 mod error;
+mod event_adapter;
 mod ipc;
 mod predicate;
 mod reconcile;
 mod reducer;
+mod runtime_state;
 mod state;
 
 use clap::Parser;
 
 use crate::config::{Cli, Config, resolve_config_path};
 use crate::error::Result;
-use crate::ipc::{CommandClient, EventStream};
-use crate::reconcile::{Reconciler, bootstrap_initial_state};
+use crate::event_adapter::EventAdapter;
+use crate::ipc::CommandClient;
+use crate::reconcile::Reconciler;
+use crate::runtime_state::RuntimeState;
 
 fn run() -> Result<()> {
     let cli = Cli::parse();
     let config_path = resolve_config_path(&cli)?;
     let config = Config::load(&config_path)?;
+    let runtime_state_path = cli.state.clone().unwrap_or_else(RuntimeState::default_path);
+    let runtime_state = RuntimeState::load(&runtime_state_path)?;
 
-    let events = EventStream::connect()?;
-    let state = bootstrap_initial_state(&events.rx, std::time::Duration::from_secs(10))?;
+    let events = EventAdapter::connect(std::time::Duration::from_secs(10))?;
     let commands = CommandClient::connect()?;
 
-    let mut reconciler = Reconciler::new(commands, events.rx, state);
+    let mut reconciler = Reconciler::new(commands, events, runtime_state, runtime_state_path);
     reconciler.run(&config)?;
 
     Ok(())

--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -10,16 +10,24 @@ pub fn workspace_active(state: &ActualState, workspace_name: &str) -> bool {
         .is_some_and(|workspace| workspace.is_active)
 }
 
+#[cfg(test)]
 pub fn window_exists_by_app_id(state: &ActualState, app_id: &str) -> bool {
     state.window_by_app_id(app_id).is_some()
 }
 
-pub fn window_on_workspace(state: &ActualState, app_id: &str, workspace_name: &str) -> bool {
+pub fn window_id_on_workspace(state: &ActualState, window_id: u64, workspace_name: &str) -> bool {
+    let workspace_id = match state.workspace_id_by_name(workspace_name) {
+        Some(id) => id,
+        None => return false,
+    };
+
     state
-        .window_id_by_app_id_on_workspace(app_id, workspace_name)
-        .is_some()
+        .windows
+        .get(&window_id)
+        .is_some_and(|window| window.workspace_id == Some(workspace_id))
 }
 
+#[cfg(test)]
 pub fn window_at_position(
     state: &ActualState,
     app_id: &str,
@@ -39,6 +47,24 @@ pub fn window_at_position(
             window.workspace_id == Some(workspace_id)
                 && window.layout.pos_in_scrolling_layout == Some((column, row))
         })
+}
+
+pub fn window_id_at_position(
+    state: &ActualState,
+    window_id: u64,
+    workspace_name: &str,
+    column: usize,
+    row: usize,
+) -> bool {
+    let workspace_id = match state.workspace_id_by_name(workspace_name) {
+        Some(id) => id,
+        None => return false,
+    };
+
+    state.windows.get(&window_id).is_some_and(|window| {
+        window.workspace_id == Some(workspace_id)
+            && window.layout.pos_in_scrolling_layout == Some((column, row))
+    })
 }
 
 pub fn column_has_window_count(
@@ -129,7 +155,15 @@ mod tests {
     fn matches_position() {
         let state = state();
         assert!(window_at_position(&state, "fw-fastfetch", "firework", 1, 1));
-        assert!(!window_at_position(&state, "fw-fastfetch", "firework", 2, 1));
+        assert!(!window_at_position(
+            &state,
+            "fw-fastfetch",
+            "firework",
+            2,
+            1
+        ));
+        assert!(window_id_at_position(&state, 1, "firework", 1, 1));
+        assert!(!window_id_at_position(&state, 1, "firework", 2, 1));
     }
 
     #[test]

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -1,17 +1,31 @@
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+#[cfg(test)]
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(test)]
+use std::time::Instant;
 
-use niri_ipc::{Action, Event, SizeChange, WorkspaceReferenceArg};
+#[cfg(test)]
+use niri_ipc::Event;
+use niri_ipc::{Action, SizeChange, WorkspaceReferenceArg};
 
 use crate::config::{ColumnSpec, Config, SizeSpec, WindowSpec, WorkspaceSpec};
 use crate::error::{NiriAutostartError, Result};
-use crate::ipc::{CommandClient, EventMessage};
+use crate::event_adapter::EventAdapter;
+use crate::ipc::CommandClient;
+#[cfg(test)]
+use crate::ipc::EventMessage;
 use crate::predicate;
+#[cfg(test)]
 use crate::reducer::apply_event;
+use crate::runtime_state::{RuntimeState, WindowKey};
 use crate::state::ActualState;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+const STABLE_FOCUS_QUIET: Duration = Duration::from_millis(150);
 
+#[cfg(test)]
 pub fn bootstrap_initial_state(
     rx: &Receiver<EventMessage>,
     timeout: Duration,
@@ -22,12 +36,13 @@ pub fn bootstrap_initial_state(
     let mut saw_windows = false;
 
     while !(saw_workspaces && saw_windows) {
-        let remaining = timeout
-            .checked_sub(start.elapsed())
-            .ok_or_else(|| NiriAutostartError::Timeout {
-                what: "initial niri event-stream state".to_string(),
-                timeout,
-            })?;
+        let remaining =
+            timeout
+                .checked_sub(start.elapsed())
+                .ok_or_else(|| NiriAutostartError::Timeout {
+                    what: "initial niri event-stream state".to_string(),
+                    timeout,
+                })?;
 
         match rx.recv_timeout(remaining) {
             Ok(EventMessage::Event(event)) => {
@@ -61,24 +76,71 @@ pub fn bootstrap_initial_state(
 
 pub struct Reconciler {
     commands: CommandClient,
-    events: Receiver<EventMessage>,
+    events: EventAdapter,
     state: ActualState,
+    runtime_state: RuntimeState,
+    runtime_state_path: PathBuf,
+    app_id_counts: HashMap<String, usize>,
 }
 
 impl Reconciler {
-    pub fn new(commands: CommandClient, events: Receiver<EventMessage>, state: ActualState) -> Self {
+    pub fn new(
+        commands: CommandClient,
+        events: EventAdapter,
+        runtime_state: RuntimeState,
+        runtime_state_path: PathBuf,
+    ) -> Self {
+        let state = events.state();
         Self {
             commands,
             events,
             state,
+            runtime_state,
+            runtime_state_path,
+            app_id_counts: HashMap::new(),
         }
     }
 
+    fn window_id_by_spec(
+        &mut self,
+        key: &WindowKey,
+        spec: &WindowSpec,
+        preferred_workspace: Option<&str>,
+    ) -> Result<Option<u64>> {
+        self.sync_state();
+
+        if let Some(window_id) = self.runtime_state.window_id(key, spec, &self.state) {
+            return Ok(Some(window_id));
+        }
+
+        if self.app_id_counts.get(&spec.app_id).copied() != Some(1) {
+            return Ok(None);
+        }
+
+        let Some(window_id) = self
+            .state
+            .preferred_window_id_by_app_id(&spec.app_id, preferred_workspace)
+            .or_else(|| self.state.preferred_window_id_by_app_id(&spec.app_id, None))
+        else {
+            return Ok(None);
+        };
+
+        self.record_runtime_window(key, spec, window_id)?;
+        Ok(Some(window_id))
+    }
+
     pub fn run(&mut self, config: &Config) -> Result<()> {
+        self.app_id_counts = app_id_counts(config);
+
         for workspace in &config.workspaces {
             self.reconcile_workspace(workspace)?;
         }
 
+        self.wait_until_quiet(
+            DEFAULT_TIMEOUT,
+            STABLE_FOCUS_QUIET,
+            "event stream to settle before final focus".to_string(),
+        )?;
         self.finalize_focus(config)?;
 
         Ok(())
@@ -113,25 +175,49 @@ impl Reconciler {
     }
 
     fn focus_workspace_first_window(&mut self, workspace: &WorkspaceSpec) -> Result<()> {
-        let Some(first_window) = workspace.columns.first().and_then(|column| column.windows.first()) else {
+        let Some(first_window) = workspace
+            .columns
+            .first()
+            .and_then(|column| column.windows.first())
+        else {
             return Ok(());
         };
+        let key = WindowKey::new(&workspace.name, 1, 1);
 
         let window_id = self
-            .state
-            .window_id_by_app_id_on_workspace(&first_window.app_id, &workspace.name)
-            .ok_or_else(|| NiriAutostartError::MissingWindow(first_window.app_id.clone()))?;
+            .window_id_by_spec(&key, first_window, Some(&workspace.name))?
+            .ok_or_else(|| NiriAutostartError::MissingWindow(window_label(&key, first_window)))?;
 
         self.ensure_workspace_active(&workspace.name)?;
-        self.commands.action(Action::FocusColumn { index: 1 })?;
-        self.commands.action(Action::FocusWindow { id: window_id })?;
-        self.wait_for(
+        self.wait_until_quiet(
             DEFAULT_TIMEOUT,
+            STABLE_FOCUS_QUIET,
+            format!(
+                "workspace {:?} to settle before final focus",
+                workspace.name
+            ),
+        )?;
+        self.commands
+            .action(Action::FocusWindow { id: window_id })?;
+        self.wait_for_stable(
+            DEFAULT_TIMEOUT,
+            STABLE_FOCUS_QUIET,
             format!(
                 "workspace {:?} first window {:?} to become focused",
-                workspace.name, first_window.app_id
+                workspace.name,
+                window_label(&key, first_window)
             ),
-            |state| state.windows.get(&window_id).is_some_and(|window| window.is_focused),
+            |state| {
+                let window_focused = state
+                    .windows
+                    .get(&window_id)
+                    .is_some_and(|window| window.is_focused);
+                let workspace_active_window = state
+                    .workspace_by_name(&workspace.name)
+                    .is_some_and(|workspace| workspace.active_window_id == Some(window_id));
+
+                window_focused && workspace_active_window
+            },
         )
     }
 
@@ -146,35 +232,38 @@ impl Reconciler {
             .first()
             .ok_or_else(|| NiriAutostartError::Validation("column without windows".to_string()))?;
 
-        let first_id = self.ensure_window_present(workspace, first)?;
-        self.ensure_primary_window_position(workspace, first, first_id, column_index)?;
+        let first_key = WindowKey::new(&workspace.name, column_index, 1);
+        let first_id = self.ensure_window_present(workspace, &first_key, first)?;
+        self.ensure_primary_window_position(workspace, &first_key, first, first_id, column_index)?;
+        let mut positioned = vec![(first_key, first, first_id)];
 
         for (row_index, window) in column.windows.iter().enumerate().skip(1) {
             let target_row = row_index + 1;
-            let window_id = self.ensure_window_present(workspace, window)?;
+            let key = WindowKey::new(&workspace.name, column_index, target_row);
+            let window_id = self.ensure_window_present(workspace, &key, window)?;
             self.ensure_stacked_window_position(
                 workspace,
+                &key,
                 window,
                 window_id,
                 column_index,
                 target_row,
             )?;
+            positioned.push((key, window, window_id));
         }
 
         self.ensure_workspace_active(&workspace.name)?;
-        self.commands.action(Action::FocusColumn { index: column_index })?;
+        self.commands.action(Action::FocusColumn {
+            index: column_index,
+        })?;
         self.commands.action(Action::SetColumnWidth {
             change: column.width.to_size_change(),
         })?;
 
-        for window in &column.windows {
-            let window_id = self
-                .state
-                .window_id_by_app_id_on_workspace(&window.app_id, &workspace.name)
-                .ok_or_else(|| NiriAutostartError::MissingWindow(window.app_id.clone()))?;
-
-            self.apply_window_floating(window_id, window.floating, &window.app_id)?;
-            self.apply_window_height(window_id, &window.app_id, window.height)?;
+        for (key, window, window_id) in positioned {
+            let label = window_label(&key, window);
+            self.apply_window_floating(window_id, window.floating, &label)?;
+            self.apply_window_height(window_id, &label, window.height)?;
         }
 
         Ok(())
@@ -194,33 +283,29 @@ impl Reconciler {
     fn ensure_window_present(
         &mut self,
         workspace: &WorkspaceSpec,
+        key: &WindowKey,
         spec: &WindowSpec,
     ) -> Result<u64> {
-        if self
-            .state
-            .preferred_window_id_by_app_id(&spec.app_id, Some(&workspace.name))
-            .is_none()
-            && self.state.first_window_id_by_app_id(&spec.app_id).is_none()
-        {
+        let label = window_label(key, spec);
+        let mut window_id = self.window_id_by_spec(key, spec, Some(&workspace.name))?;
+
+        if window_id.is_none() {
+            let before = self.state.windows.keys().copied().collect::<HashSet<_>>();
             self.commands.action(Action::Spawn {
                 command: spec.command.clone(),
             })?;
-            self.wait_for(
-                DEFAULT_TIMEOUT,
-                format!("window {:?} to appear", spec.app_id),
-                |state| predicate::window_exists_by_app_id(state, &spec.app_id),
-            )?;
+            let spawned_id =
+                self.wait_for_spawned_window(DEFAULT_TIMEOUT, &label, &before, spec)?;
+            self.record_runtime_window(key, spec, spawned_id)?;
+            window_id = Some(spawned_id);
         }
 
-        let window_id = self
-            .state
-            .preferred_window_id_by_app_id(&spec.app_id, Some(&workspace.name))
-            .or_else(|| self.state.first_window_id_by_app_id(&spec.app_id))
-            .ok_or_else(|| NiriAutostartError::MissingWindow(spec.app_id.clone()))?;
+        let window_id =
+            window_id.ok_or_else(|| NiriAutostartError::MissingWindow(label.clone()))?;
 
         self.ensure_workspace_active(&workspace.name)?;
 
-        if !predicate::window_on_workspace(&self.state, &spec.app_id, &workspace.name) {
+        if !predicate::window_id_on_workspace(&self.state, window_id, &workspace.name) {
             self.commands.action(Action::MoveWindowToWorkspace {
                 window_id: Some(window_id),
                 reference: WorkspaceReferenceArg::Name(workspace.name.clone()),
@@ -228,34 +313,29 @@ impl Reconciler {
             })?;
             self.wait_for(
                 DEFAULT_TIMEOUT,
-                format!("window {:?} to move to workspace {:?}", spec.app_id, workspace.name),
-                |state| predicate::window_on_workspace(state, &spec.app_id, &workspace.name),
+                format!("window {label:?} to move to workspace {:?}", workspace.name),
+                |state| predicate::window_id_on_workspace(state, window_id, &workspace.name),
             )?;
         }
 
-        Ok(self
-            .state
-            .window_id_by_app_id_on_workspace(&spec.app_id, &workspace.name)
-            .or_else(|| {
-                self.state
-                    .preferred_window_id_by_app_id(&spec.app_id, Some(&workspace.name))
-            })
-            .ok_or_else(|| NiriAutostartError::MissingWindow(spec.app_id.clone()))?)
+        Ok(window_id)
     }
 
     fn ensure_primary_window_position(
         &mut self,
         workspace: &WorkspaceSpec,
+        key: &WindowKey,
         spec: &WindowSpec,
         window_id: u64,
         target_column: usize,
     ) -> Result<()> {
-        self.apply_window_floating(window_id, spec.floating, &spec.app_id)?;
-        self.ensure_window_row(window_id, &spec.app_id, 1)?;
+        let label = window_label(key, spec);
+        self.apply_window_floating(window_id, spec.floating, &label)?;
+        self.ensure_window_row(window_id, &label, 1)?;
 
-        if predicate::window_at_position(
+        if predicate::window_id_at_position(
             &self.state,
-            &spec.app_id,
+            window_id,
             &workspace.name,
             target_column,
             1,
@@ -264,39 +344,48 @@ impl Reconciler {
         }
 
         self.ensure_workspace_active(&workspace.name)?;
-        self.commands.action(Action::FocusWindow { id: window_id })?;
+        self.commands
+            .action(Action::FocusWindow { id: window_id })?;
         self.wait_for(
             DEFAULT_TIMEOUT,
-            format!("window {:?} to become focused", spec.app_id),
-            |state| state.windows.get(&window_id).is_some_and(|window| window.is_focused),
+            format!("window {label:?} to become focused"),
+            |state| {
+                state
+                    .windows
+                    .get(&window_id)
+                    .is_some_and(|window| window.is_focused)
+            },
         )?;
-        self.commands.action(Action::MoveColumnToIndex { index: target_column })?;
+        self.commands.action(Action::MoveColumnToIndex {
+            index: target_column,
+        })?;
         self.wait_for(
             DEFAULT_TIMEOUT,
-            format!(
-                "window {:?} to reach column {} row 1",
-                spec.app_id, target_column
-            ),
-            |state| state.windows.get(&window_id).is_some_and(|window| {
-                window.workspace_id == state.workspace_id_by_name(&workspace.name)
-                    && window.layout.pos_in_scrolling_layout == Some((target_column, 1))
-            }),
+            format!("window {:?} to reach column {} row 1", label, target_column),
+            |state| {
+                state.windows.get(&window_id).is_some_and(|window| {
+                    window.workspace_id == state.workspace_id_by_name(&workspace.name)
+                        && window.layout.pos_in_scrolling_layout == Some((target_column, 1))
+                })
+            },
         )
     }
 
     fn ensure_stacked_window_position(
         &mut self,
         workspace: &WorkspaceSpec,
+        key: &WindowKey,
         spec: &WindowSpec,
         window_id: u64,
         target_column: usize,
         target_row: usize,
     ) -> Result<()> {
-        self.apply_window_floating(window_id, spec.floating, &spec.app_id)?;
+        let label = window_label(key, spec);
+        self.apply_window_floating(window_id, spec.floating, &label)?;
 
-        if predicate::window_at_position(
+        if predicate::window_id_at_position(
             &self.state,
-            &spec.app_id,
+            window_id,
             &workspace.name,
             target_column,
             target_row,
@@ -307,29 +396,36 @@ impl Reconciler {
         let (current_column, _) = self
             .state
             .window_position_by_id(window_id)
-            .ok_or_else(|| NiriAutostartError::MissingWindow(spec.app_id.clone()))?;
+            .ok_or_else(|| NiriAutostartError::MissingWindow(label.clone()))?;
 
         if current_column == target_column {
-            return self.ensure_window_row(window_id, &spec.app_id, target_row);
+            return self.ensure_window_row(window_id, &label, target_row);
         }
 
         self.ensure_workspace_active(&workspace.name)?;
-        self.commands.action(Action::FocusWindow { id: window_id })?;
+        self.commands
+            .action(Action::FocusWindow { id: window_id })?;
         self.wait_for(
             DEFAULT_TIMEOUT,
-            format!("window {:?} to become focused", spec.app_id),
-            |state| state.windows.get(&window_id).is_some_and(|window| window.is_focused),
+            format!("window {label:?} to become focused"),
+            |state| {
+                state
+                    .windows
+                    .get(&window_id)
+                    .is_some_and(|window| window.is_focused)
+            },
         )?;
 
         let desired_column = target_column + 1;
         if current_column != desired_column {
-            self.commands
-                .action(Action::MoveColumnToIndex { index: desired_column })?;
+            self.commands.action(Action::MoveColumnToIndex {
+                index: desired_column,
+            })?;
             self.wait_for(
                 DEFAULT_TIMEOUT,
                 format!(
                     "window {:?} to move to helper column {}",
-                    spec.app_id, desired_column
+                    label, desired_column
                 ),
                 |state| {
                     state
@@ -343,28 +439,36 @@ impl Reconciler {
             .state
             .window_position_by_id(window_id)
             .map(|(column, _)| column)
-            .ok_or_else(|| NiriAutostartError::MissingWindow(spec.app_id.clone()))?;
+            .ok_or_else(|| NiriAutostartError::MissingWindow(label.clone()))?;
         if helper_column != desired_column {
             return Err(NiriAutostartError::NonAdjacentColumn {
-                app_id: spec.app_id.clone(),
+                app_id: label.clone(),
                 actual: helper_column,
                 expected_left: target_column,
             });
         }
 
-        self.commands.action(Action::FocusColumn { index: target_column })?;
+        self.commands.action(Action::FocusColumn {
+            index: target_column,
+        })?;
         self.commands.action(Action::ConsumeWindowIntoColumn {})?;
         self.wait_for(
             DEFAULT_TIMEOUT,
             format!(
                 "window {:?} to reach column {} row {}",
-                spec.app_id, target_column, target_row
+                label, target_column, target_row
             ),
             |state| {
                 state.windows.get(&window_id).is_some_and(|window| {
                     window.workspace_id == state.workspace_id_by_name(&workspace.name)
-                        && window.layout.pos_in_scrolling_layout == Some((target_column, target_row))
-                }) && predicate::column_has_window_count(state, &workspace.name, target_column, target_row)
+                        && window.layout.pos_in_scrolling_layout
+                            == Some((target_column, target_row))
+                }) && predicate::column_has_window_count(
+                    state,
+                    &workspace.name,
+                    target_column,
+                    target_row,
+                )
             },
         )
     }
@@ -379,11 +483,17 @@ impl Reconciler {
                 return Ok(());
             }
 
-            self.commands.action(Action::FocusWindow { id: window_id })?;
+            self.commands
+                .action(Action::FocusWindow { id: window_id })?;
             self.wait_for(
                 DEFAULT_TIMEOUT,
                 format!("window {:?} to become focused", app_id),
-                |state| state.windows.get(&window_id).is_some_and(|window| window.is_focused),
+                |state| {
+                    state
+                        .windows
+                        .get(&window_id)
+                        .is_some_and(|window| window.is_focused)
+                },
             )?;
 
             if current_row < target_row {
@@ -414,7 +524,12 @@ impl Reconciler {
         }
     }
 
-    fn apply_window_floating(&mut self, window_id: u64, floating: bool, app_id: &str) -> Result<()> {
+    fn apply_window_floating(
+        &mut self,
+        window_id: u64,
+        floating: bool,
+        app_id: &str,
+    ) -> Result<()> {
         let is_floating = self
             .state
             .windows
@@ -439,11 +554,21 @@ impl Reconciler {
         self.wait_for(
             DEFAULT_TIMEOUT,
             format!("window {:?} floating state to become {}", app_id, floating),
-            |state| state.windows.get(&window_id).is_some_and(|window| window.is_floating == floating),
+            |state| {
+                state
+                    .windows
+                    .get(&window_id)
+                    .is_some_and(|window| window.is_floating == floating)
+            },
         )
     }
 
-    fn apply_window_height(&mut self, window_id: u64, app_id: &str, height: SizeSpec) -> Result<()> {
+    fn apply_window_height(
+        &mut self,
+        window_id: u64,
+        app_id: &str,
+        height: SizeSpec,
+    ) -> Result<()> {
         self.commands.action(Action::SetWindowHeight {
             id: Some(window_id),
             change: height.to_size_change(),
@@ -470,44 +595,117 @@ impl Reconciler {
         Ok(())
     }
 
+    fn wait_for_spawned_window(
+        &mut self,
+        timeout: Duration,
+        label: &str,
+        before: &HashSet<u64>,
+        spec: &WindowSpec,
+    ) -> Result<u64> {
+        self.events
+            .wait_for(timeout, format!("window {label:?} to appear"), |state| {
+                Self::spawned_window_id_in_state(state, before, spec).is_some()
+            })?;
+        self.sync_state();
+
+        self.spawned_window_id(before, spec)
+            .ok_or_else(|| NiriAutostartError::MissingWindow(label.to_string()))
+    }
+
+    fn spawned_window_id(&self, before: &HashSet<u64>, spec: &WindowSpec) -> Option<u64> {
+        Self::spawned_window_id_in_state(&self.state, before, spec)
+    }
+
+    fn spawned_window_id_in_state(
+        state: &ActualState,
+        before: &HashSet<u64>,
+        spec: &WindowSpec,
+    ) -> Option<u64> {
+        state
+            .windows
+            .values()
+            .filter(|window| {
+                !before.contains(&window.id)
+                    && window.app_id.as_deref() == Some(spec.app_id.as_str())
+            })
+            .max_by_key(|window| (!window.is_floating, window.is_focused, window.id))
+            .map(|window| window.id)
+    }
+
+    fn record_runtime_window(
+        &mut self,
+        key: &WindowKey,
+        spec: &WindowSpec,
+        window_id: u64,
+    ) -> Result<()> {
+        let window = self
+            .state
+            .windows
+            .get(&window_id)
+            .cloned()
+            .ok_or_else(|| NiriAutostartError::MissingWindow(window_label(key, spec)))?;
+
+        self.runtime_state.record(key, spec, &window);
+        self.runtime_state.persist(&self.runtime_state_path)
+    }
+
     fn wait_for<F>(&mut self, timeout: Duration, what: String, predicate: F) -> Result<()>
     where
         F: Fn(&ActualState) -> bool,
     {
-        if predicate(&self.state) {
-            return Ok(());
-        }
+        self.events.wait_for(timeout, what, predicate)?;
+        self.sync_state();
+        Ok(())
+    }
 
-        let start = Instant::now();
-        loop {
-            let remaining = timeout
-                .checked_sub(start.elapsed())
-                .ok_or_else(|| NiriAutostartError::Timeout {
-                    what: what.clone(),
-                    timeout,
-                })?;
+    fn wait_for_stable<F>(
+        &mut self,
+        timeout: Duration,
+        quiet_for: Duration,
+        what: String,
+        predicate: F,
+    ) -> Result<()>
+    where
+        F: Fn(&ActualState) -> bool,
+    {
+        self.events
+            .wait_for_stable(timeout, quiet_for, what, predicate)?;
+        self.sync_state();
+        Ok(())
+    }
 
-            match self.events.recv_timeout(remaining) {
-                Ok(EventMessage::Event(event)) => {
-                    apply_event(&mut self.state, event);
-                    if predicate(&self.state) {
-                        return Ok(());
-                    }
-                }
-                Ok(EventMessage::Closed(message)) => {
-                    return Err(NiriAutostartError::EventStreamClosed(message));
-                }
-                Err(RecvTimeoutError::Timeout) => {
-                    return Err(NiriAutostartError::Timeout { what, timeout });
-                }
-                Err(RecvTimeoutError::Disconnected) => {
-                    return Err(NiriAutostartError::EventStreamClosed(
-                        "event thread disconnected".to_string(),
-                    ));
-                }
+    fn wait_until_quiet(
+        &mut self,
+        timeout: Duration,
+        quiet_for: Duration,
+        what: String,
+    ) -> Result<()> {
+        self.events.wait_until_quiet(timeout, quiet_for, what)?;
+        self.sync_state();
+        Ok(())
+    }
+
+    fn sync_state(&mut self) {
+        self.state = self.events.state();
+    }
+}
+
+fn app_id_counts(config: &Config) -> HashMap<String, usize> {
+    let mut counts = HashMap::new();
+
+    for workspace in &config.workspaces {
+        for column in &workspace.columns {
+            for window in &column.windows {
+                *counts.entry(window.app_id.clone()).or_insert(0) += 1;
             }
         }
     }
+
+    counts
+}
+
+fn window_label(key: &WindowKey, spec: &WindowSpec) -> String {
+    format!("{} at {}", spec.app_id, key)
 }
 
 impl SizeSpec {

--- a/src/reducer.rs
+++ b/src/reducer.rs
@@ -82,10 +82,7 @@ pub fn apply_event(state: &mut ActualState, event: Event) {
         Event::ConfigLoaded { failed } => {
             state.last_config_loaded_failed = Some(failed);
         }
-        Event::KeyboardLayoutsChanged { .. }
-        | Event::KeyboardLayoutSwitched { .. }
-        | Event::OverviewOpenedOrClosed { .. }
-        | Event::ScreenshotCaptured { .. } => {}
+        _ => {}
     }
 }
 

--- a/src/reducer.rs
+++ b/src/reducer.rs
@@ -12,7 +12,10 @@ pub fn apply_event(state: &mut ActualState, event: Event) {
             state.rebuild_indices();
         }
         Event::WorkspaceActivated { id, focused } => {
-            let output = state.workspaces.get(&id).and_then(|workspace| workspace.output.clone());
+            let output = state
+                .workspaces
+                .get(&id)
+                .and_then(|workspace| workspace.output.clone());
 
             if let Some(output) = output {
                 for workspace in state.workspaces.values_mut() {
@@ -59,7 +62,10 @@ pub fn apply_event(state: &mut ActualState, event: Event) {
             }
             state.rebuild_indices();
         }
-        Event::WindowFocusTimestampChanged { id, focus_timestamp } => {
+        Event::WindowFocusTimestampChanged {
+            id,
+            focus_timestamp,
+        } => {
             if let Some(window) = state.windows.get_mut(&id) {
                 window.focus_timestamp = focus_timestamp;
             }

--- a/src/runtime_state.rs
+++ b/src/runtime_state.rs
@@ -1,0 +1,232 @@
+use std::env;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use niri_ipc::Window;
+use serde::{Deserialize, Serialize};
+
+use crate::config::WindowSpec;
+use crate::error::{NiriAutostartError, Result};
+use crate::state::ActualState;
+
+const STATE_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowKey {
+    pub workspace: String,
+    pub column: usize,
+    pub row: usize,
+}
+
+impl WindowKey {
+    pub fn new(workspace: &str, column: usize, row: usize) -> Self {
+        Self {
+            workspace: workspace.to_string(),
+            column,
+            row,
+        }
+    }
+}
+
+impl std::fmt::Display for WindowKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}:{}", self.workspace, self.column, self.row)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RuntimeState {
+    version: u32,
+    #[serde(default)]
+    windows: Vec<StoredWindow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct StoredWindow {
+    workspace: String,
+    column: usize,
+    row: usize,
+    window_id: u64,
+    app_id: String,
+    pid: Option<i32>,
+    command: Vec<String>,
+}
+
+impl Default for RuntimeState {
+    fn default() -> Self {
+        Self {
+            version: STATE_VERSION,
+            windows: Vec::new(),
+        }
+    }
+}
+
+impl RuntimeState {
+    pub fn default_path() -> PathBuf {
+        env::temp_dir().join("niri-autostart").join("windows.json")
+    }
+
+    pub fn load(path: &Path) -> Result<Self> {
+        let text = match fs::read_to_string(path) {
+            Ok(text) => text,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Self::default()),
+            Err(source) => {
+                return Err(NiriAutostartError::RuntimeStateRead {
+                    path: path.to_path_buf(),
+                    source,
+                });
+            }
+        };
+
+        let mut state: Self =
+            serde_json::from_str(&text).map_err(|err| NiriAutostartError::RuntimeStateParse {
+                path: path.to_path_buf(),
+                message: err.to_string(),
+            })?;
+        state.version = STATE_VERSION;
+        Ok(state)
+    }
+
+    pub fn persist(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|source| NiriAutostartError::RuntimeStateWrite {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+
+        let text = serde_json::to_string_pretty(self)
+            .map_err(|err| NiriAutostartError::RuntimeStateSerialize(err.to_string()))?;
+        let tmp = path.with_extension("tmp");
+        fs::write(&tmp, text).map_err(|source| NiriAutostartError::RuntimeStateWrite {
+            path: tmp.clone(),
+            source,
+        })?;
+        fs::rename(&tmp, path).map_err(|source| NiriAutostartError::RuntimeStateWrite {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+        Ok(())
+    }
+
+    pub fn window_id(
+        &self,
+        key: &WindowKey,
+        spec: &WindowSpec,
+        state: &ActualState,
+    ) -> Option<u64> {
+        let stored = self.windows.iter().find(|stored| stored.matches_key(key))?;
+
+        if stored.app_id != spec.app_id || stored.command != spec.command {
+            return None;
+        }
+
+        let window = state.windows.get(&stored.window_id)?;
+        if window.app_id.as_deref() != Some(spec.app_id.as_str()) || window.pid != stored.pid {
+            return None;
+        }
+
+        Some(stored.window_id)
+    }
+
+    pub fn record(&mut self, key: &WindowKey, spec: &WindowSpec, window: &Window) {
+        let stored = StoredWindow {
+            workspace: key.workspace.clone(),
+            column: key.column,
+            row: key.row,
+            window_id: window.id,
+            app_id: spec.app_id.clone(),
+            pid: window.pid,
+            command: spec.command.clone(),
+        };
+
+        if let Some(existing) = self
+            .windows
+            .iter_mut()
+            .find(|existing| existing.matches_key(key))
+        {
+            *existing = stored;
+        } else {
+            self.windows.push(stored);
+        }
+
+        self.windows
+            .sort_by_key(|stored| (stored.workspace.clone(), stored.column, stored.row));
+    }
+}
+
+impl StoredWindow {
+    fn matches_key(&self, key: &WindowKey) -> bool {
+        self.workspace == key.workspace && self.column == key.column && self.row == key.row
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use niri_ipc::{Timestamp, WindowLayout};
+
+    fn spec(command: &[&str]) -> WindowSpec {
+        WindowSpec {
+            app_id: "kitty".into(),
+            command: command.iter().map(|arg| (*arg).to_string()).collect(),
+            height: crate::config::SizeSpec::Proportion(1.0),
+            floating: false,
+        }
+    }
+
+    fn window(id: u64, app_id: &str, pid: Option<i32>) -> Window {
+        Window {
+            id,
+            title: None,
+            app_id: Some(app_id.to_string()),
+            pid,
+            workspace_id: Some(1),
+            is_focused: false,
+            is_floating: false,
+            is_urgent: false,
+            layout: WindowLayout {
+                pos_in_scrolling_layout: Some((1, 1)),
+                tile_size: (100.0, 100.0),
+                window_size: (100, 100),
+                tile_pos_in_workspace_view: None,
+                window_offset_in_tile: (0.0, 0.0),
+            },
+            focus_timestamp: Some(Timestamp { secs: 0, nanos: 0 }),
+        }
+    }
+
+    #[test]
+    fn resolves_recorded_live_window() {
+        let key = WindowKey::new("code", 1, 1);
+        let spec = spec(&["terminal", "-e", "nvim"]);
+        let window = window(42, "kitty", Some(1000));
+
+        let mut runtime = RuntimeState::default();
+        runtime.record(&key, &spec, &window);
+
+        let mut state = ActualState::default();
+        state.replace_windows(vec![window]);
+
+        assert_eq!(runtime.window_id(&key, &spec, &state), Some(42));
+    }
+
+    #[test]
+    fn ignores_stale_or_shifted_entries() {
+        let key = WindowKey::new("code", 1, 1);
+        let window_spec = spec(&["terminal", "-e", "nvim"]);
+        let changed_spec = spec(&["terminal", "-e", "fish"]);
+        let recorded_window = window(42, "kitty", Some(1000));
+
+        let mut runtime = RuntimeState::default();
+        runtime.record(&key, &window_spec, &recorded_window);
+
+        let mut state = ActualState::default();
+        state.replace_windows(vec![window(42, "kitty", Some(1001))]);
+
+        assert_eq!(runtime.window_id(&key, &window_spec, &state), None);
+        assert_eq!(runtime.window_id(&key, &changed_spec, &state), None);
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -45,7 +45,8 @@ impl ActualState {
             if let (Some(workspace_id), Some((column, row))) =
                 (window.workspace_id, window.layout.pos_in_scrolling_layout)
             {
-                self.positions.insert((workspace_id, column, row), window.id);
+                self.positions
+                    .insert((workspace_id, column, row), window.id);
             }
         }
     }
@@ -64,35 +65,46 @@ impl ActualState {
         app_id: &str,
         preferred_workspace: Option<&str>,
     ) -> Option<u64> {
-        let preferred_workspace_id = preferred_workspace.and_then(|name| self.workspace_id_by_name(name));
+        let preferred_workspace_id =
+            preferred_workspace.and_then(|name| self.workspace_id_by_name(name));
 
-        self.windows_by_app_id.get(app_id).and_then(|ids| {
-            ids.iter()
-                .filter_map(|id| self.windows.get(id).map(|window| (*id, window)))
-                .max_by_key(|(id, window)| {
-                    (
-                        preferred_workspace_id.is_some_and(|workspace_id| {
-                            window.workspace_id == Some(workspace_id)
-                        }),
-                        !window.is_floating,
-                        window.is_focused,
-                        *id,
-                    )
-                })
-                .map(|(id, _)| id)
-        })
+        self.windows_by_app_id
+            .get(app_id)?
+            .iter()
+            .filter_map(|id| self.windows.get(id).map(|window| (*id, window)))
+            .max_by_key(|window| {
+                (
+                    preferred_workspace_id
+                        .is_some_and(|workspace_id| window.1.workspace_id == Some(workspace_id)),
+                    !window.1.is_floating,
+                    window.1.is_focused,
+                    window.0,
+                )
+            })
+            .map(|(id, _)| id)
     }
 
+    #[cfg(test)]
     pub fn first_window_id_by_app_id(&self, app_id: &str) -> Option<u64> {
         self.preferred_window_id_by_app_id(app_id, None)
     }
 
-    pub fn window_id_by_app_id_on_workspace(&self, app_id: &str, workspace_name: &str) -> Option<u64> {
+    #[cfg(test)]
+    pub fn window_id_by_app_id_on_workspace(
+        &self,
+        app_id: &str,
+        workspace_name: &str,
+    ) -> Option<u64> {
         let workspace_id = self.workspace_id_by_name(workspace_name)?;
         self.preferred_window_id_by_app_id(app_id, Some(workspace_name))
-            .filter(|id| self.windows.get(id).is_some_and(|window| window.workspace_id == Some(workspace_id)))
+            .filter(|id| {
+                self.windows
+                    .get(id)
+                    .is_some_and(|window| window.workspace_id == Some(workspace_id))
+            })
     }
 
+    #[cfg(test)]
     pub fn window_by_app_id(&self, app_id: &str) -> Option<&Window> {
         self.first_window_id_by_app_id(app_id)
             .and_then(|id| self.windows.get(&id))
@@ -130,9 +142,20 @@ mod tests {
     use niri_ipc::{Timestamp, WindowLayout};
 
     fn window(id: u64, app_id: &str, workspace_id: u64, column: usize, row: usize) -> Window {
+        window_with_title(id, app_id, app_id, workspace_id, column, row)
+    }
+
+    fn window_with_title(
+        id: u64,
+        app_id: &str,
+        title: &str,
+        workspace_id: u64,
+        column: usize,
+        row: usize,
+    ) -> Window {
         Window {
             id,
-            title: Some(app_id.to_string()),
+            title: Some(title.to_string()),
             app_id: Some(app_id.to_string()),
             pid: Some(1),
             workspace_id: Some(workspace_id),
@@ -203,7 +226,11 @@ mod tests {
         let tiled_elsewhere = window(2, "org.telegram.desktop", 11, 1, 1);
         let tiled_on_internet = window(3, "org.telegram.desktop", 10, 2, 1);
 
-        state.replace_windows(vec![floating_on_internet, tiled_elsewhere, tiled_on_internet]);
+        state.replace_windows(vec![
+            floating_on_internet,
+            tiled_elsewhere,
+            tiled_on_internet,
+        ]);
 
         assert_eq!(
             state.window_id_by_app_id_on_workspace("org.telegram.desktop", "internet"),


### PR DESCRIPTION
Release PR from dev to main.

Squash merge this PR with commit title:

```text
v0.2.0
```

Included:
- runtime-state identity for repeated app ids
- continuous event-stream adapter for reconciliation
- documentation updates for the new matching model
- version bump to v0.2.0

Checks run locally:
- cargo test
- cargo clippy --all-targets -- -D warnings